### PR TITLE
fix: component render's function

### DIFF
--- a/src/vue-feather.vue
+++ b/src/vue-feather.vue
@@ -106,13 +106,8 @@ export default defineComponent({
             'stroke-width': this.strokeWidth,
             width: size,
             class: [icon.attrs.class, 'vue-feather__content'],
+            innerHTML: icon.contents,
           },
-
-          [
-            h({
-              template: icon.contents,
-            }),
-          ],
         ),
       ],
     );


### PR DESCRIPTION
I've got the same issue as #8 

so I look into the render function and I've found that the problem might be with these lines

https://github.com/fengyuanchen/vue-feather/blob/cecbf9a0d9427406d4db622241a4935a5b5d1f09/src/vue-feather.vue#L111-L115

since the content of `svg` is the icon's path, so I try to use `innerHTML` instead and the problem is gone.

would it be better to use `innerHTML` of vnode property instead of `h({ template: icon.contents })`?