### PR TITLE
feat: add iconClass prop

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "eslint.format.enable": true,
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8072,9 +8072,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true,
       "funding": [
         {
@@ -12541,9 +12541,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -12917,9 +12917,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true,
       "engines": {
         "node": ">= 6.13.0"
@@ -24568,9 +24568,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "form-data": {
@@ -27902,9 +27902,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {
@@ -28162,9 +28162,9 @@
       }
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true
     },
     "node-int64": {

--- a/src/README.md
+++ b/src/README.md
@@ -99,6 +99,14 @@ export default {
 </template>
 ```
 
+## Icon Class
+
+```html
+<template>
+  <vue-feather type="star" icon-class="custom-class"></vue-feather>
+</template>
+```
+
 ## Sizes
 
 ```html
@@ -181,6 +189,7 @@ p > i {
 | animation | `string` | - | spin, pulse | The animation type of the icon. |
 | animation-speed | `string` | - | slow, fast | The animation speed of the icon. |
 | fill | `string` | `"none"` | - | The fill color of the icon ([spec](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fill)). |
+| icon-class | `string` | `""` | - | A string of classes to assign to the icon element. This is useful for implementation with CSS frameworks, such as Tailwind CSS. |
 | size | `number \| string` | `24` | - | The size of the icon. Set both width and height of the icon. |
 | stroke | `string` | `"currentColor"` | - | The stroke color of the icon ([spec](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke)). |
 | stroke-linecap | `string` | `"round"` | butt, round, square | Specifies the shape to be used at the end of open subpaths when they are stroked ([spec](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-linecap)). |

--- a/src/vue-feather.vue
+++ b/src/vue-feather.vue
@@ -21,6 +21,11 @@ export default defineComponent({
       default: 'none',
     },
 
+    iconClass: {
+      type: String,
+      default: '',
+    },
+
     size: {
       type: [Number, String],
       default: 24,
@@ -121,7 +126,7 @@ export default defineComponent({
             'stroke-linejoin': this.strokeLinejoin,
             'stroke-width': this.strokeWidth,
             width: isRemSize ? undefined : size,
-            class: [icon.attrs.class, 'vue-feather__content'],
+            class: [icon.attrs.class, 'vue-feather__content', this.iconClass],
             innerHTML: icon.contents,
           },
         ),

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -78,6 +78,17 @@ describe('props', () => {
     expect(wrapper.find('svg').attributes('fill')).toBe('red');
   });
 
+  it('iconClass', () => {
+    const wrapper = mount(VueFeather, {
+      props: {
+        iconClass: 'custom-class',
+      },
+    });
+
+    expect(wrapper.props('iconClass')).toBe('custom-class');
+    expect(wrapper.find('svg').attributes('class')).toContain('custom-class');
+  });
+
   describe('size', () => {
     it('number', () => {
       const wrapper = mount(VueFeather, {


### PR DESCRIPTION
I use Tailwind CSS and would like to be able to add classes to the `svg` element, thereby allowing me to use stroke and fill classes with any custom theming I've applied and not rely on resolving my Tailwind config or Tailwind's `colors` exported in their package.

In addition, I fixed a few security vulnerabilities (noticed them when I installed the deps) as well as added some VS Code settings and extension recommendations due to conflicts with my own setup that uses Prettier as the default formatter.

Let me know what you think and if there's anything else you'd like me to change (e.g. bump the `version`).